### PR TITLE
bumped openapitools from 4.3.1 to 5.1.1

### DIFF
--- a/src/backend/ai-reviewer-cso-api/src/main/java/ca/bc/gov/open/jag/aireviewercsoapi/model/ProcessedDocument.java
+++ b/src/backend/ai-reviewer-cso-api/src/main/java/ca/bc/gov/open/jag/aireviewercsoapi/model/ProcessedDocument.java
@@ -1,6 +1,5 @@
 package ca.bc.gov.open.jag.aireviewercsoapi.model;
 
-import java.net.URI;
 import java.math.BigDecimal;
 import java.util.UUID;
 

--- a/src/backend/ai-reviewer-cso-api/src/test/java/ca/bc/gov/open/jag/aireviewercsoapi/extract/ExtractApiDelegateImplTest.java
+++ b/src/backend/ai-reviewer-cso-api/src/test/java/ca/bc/gov/open/jag/aireviewercsoapi/extract/ExtractApiDelegateImplTest.java
@@ -1,21 +1,24 @@
 package ca.bc.gov.open.jag.aireviewercsoapi.extract;
 
-import ca.bc.gov.open.jag.aireviewercsoapi.api.model.ExtractNotification;
-import ca.bc.gov.open.jag.aireviewercsoapi.service.ProcessedDocumentService;
-import org.junit.jupiter.api.*;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.math.BigDecimal;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mock;
-import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.math.BigDecimal;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.UUID;
-
-import static org.mockito.ArgumentMatchers.any;
+import ca.bc.gov.open.jag.aireviewercsoapi.api.model.ExtractNotification;
+import ca.bc.gov.open.jag.aireviewercsoapi.service.ProcessedDocumentService;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ExtractApiDelegateImplTest {

--- a/src/backend/ai-reviewer-cso-api/src/test/java/ca/bc/gov/open/jag/aireviewercsoapi/service/ProcessedDocumentServiceImplTest.java
+++ b/src/backend/ai-reviewer-cso-api/src/test/java/ca/bc/gov/open/jag/aireviewercsoapi/service/ProcessedDocumentServiceImplTest.java
@@ -1,24 +1,24 @@
 package ca.bc.gov.open.jag.aireviewercsoapi.service;
 
-import ca.bc.gov.open.jag.aireviewercsoapi.extract.ExtractApiDelegateImpl;
-import ca.bc.gov.open.jag.aireviewercsoapi.model.ProcessedDocument;
-import com.sun.org.apache.regexp.internal.RE;
-import org.junit.jupiter.api.*;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.math.BigDecimal;
+import java.net.URISyntaxException;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
-import java.math.BigDecimal;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.UUID;
-
-
-import static org.mockito.ArgumentMatchers.any;
+import ca.bc.gov.open.jag.aireviewercsoapi.model.ProcessedDocument;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ProcessedDocumentServiceImplTest {

--- a/src/backend/ai-reviewer-mock-api/src/main/java/ca/bc/gov/open/jag/aireviewermockapi/controller/DocumentController.java
+++ b/src/backend/ai-reviewer-mock-api/src/main/java/ca/bc/gov/open/jag/aireviewermockapi/controller/DocumentController.java
@@ -1,19 +1,17 @@
 package ca.bc.gov.open.jag.aireviewermockapi.controller;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.stream.Collectors;
 
 @Controller
 public class DocumentController {

--- a/src/backend/ai-reviewer-mock-api/src/main/java/ca/bc/gov/open/jag/aireviewermockapi/controller/ParentController.java
+++ b/src/backend/ai-reviewer-mock-api/src/main/java/ca/bc/gov/open/jag/aireviewermockapi/controller/ParentController.java
@@ -1,16 +1,17 @@
 package ca.bc.gov.open.jag.aireviewermockapi.controller;
 
-import ca.bc.gov.open.jag.aireviewermockapi.model.DocumentReady;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.client.RestTemplate;
 
-import java.text.MessageFormat;
-import java.util.UUID;
+import ca.bc.gov.open.jag.aireviewermockapi.model.DocumentReady;
 
 @Controller
 public class ParentController {

--- a/src/backend/ai-reviewer-mock-api/src/test/java/ca/bc/gov/open/jag/aireviewermockapi/controller/DocumentControllerTest.java
+++ b/src/backend/ai-reviewer-mock-api/src/test/java/ca/bc/gov/open/jag/aireviewermockapi/controller/DocumentControllerTest.java
@@ -1,11 +1,14 @@
 package ca.bc.gov.open.jag.aireviewermockapi.controller;
 
-import org.junit.jupiter.api.*;
-import org.springframework.boot.test.context.SpringBootTest;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
-import java.io.IOException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DocumentControllerTest {

--- a/src/backend/efiling-reviewer-api/pom.xml
+++ b/src/backend/efiling-reviewer-api/pom.xml
@@ -243,7 +243,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>4.3.1</version>
+				<version>5.1.1</version>
 				<executions>
 					<execution>
 						<id>spring-boot-api</id>

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/Keys.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/Keys.java
@@ -1,9 +1,7 @@
 package ca.bc.gov.open.jag.efilingreviewerapi;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class Keys {
 

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/documentconfiguration/DocumentConfigurationsApiDelegateImpl.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/documentconfiguration/DocumentConfigurationsApiDelegateImpl.java
@@ -1,24 +1,21 @@
 package ca.bc.gov.open.jag.efilingreviewerapi.documentconfiguration;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
 import ca.bc.gov.open.jag.efilingreviewerapi.api.DocumentTypeConfigurationsApiDelegate;
 import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentTypeConfigurationRequest;
 import ca.bc.gov.open.jag.efilingreviewerapi.document.models.DocumentTypeConfiguration;
 import ca.bc.gov.open.jag.efilingreviewerapi.document.store.DocumentTypeConfigurationRepository;
 import ca.bc.gov.open.jag.efilingreviewerapi.documentconfiguration.mappers.DocumentTypeConfigurationMapper;
 import ca.bc.gov.open.jag.efilingreviewerapi.error.AiReviewerDocumentTypeConfigurationException;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
-
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import javax.validation.Valid;
 
 @Service
 public class DocumentConfigurationsApiDelegateImpl implements DocumentTypeConfigurationsApiDelegate {

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/error/AiReviewerControllerAdvisor.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/error/AiReviewerControllerAdvisor.java
@@ -1,5 +1,15 @@
 package ca.bc.gov.open.jag.efilingreviewerapi.error;
 
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
 import ca.bc.gov.open.efilingdiligenclient.exception.DiligenAuthenticationException;
 import ca.bc.gov.open.efilingdiligenclient.exception.DiligenDocumentException;
 import ca.bc.gov.open.jag.efilingreviewerapi.api.model.ApiError;
@@ -8,16 +18,6 @@ import ca.bc.gov.open.jag.jagmailit.api.handler.ApiException;
 import ca.bc.gov.open.jag.jagmailit.api.model.EmailObject;
 import ca.bc.gov.open.jag.jagmailit.api.model.EmailRequest;
 import ca.bc.gov.open.jag.jagmailit.api.model.EmailRequestContent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.context.request.WebRequest;
-
-import java.util.Collections;
 
 @ControllerAdvice
 @EnableConfigurationProperties(ErrorEmailProperties.class)

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mappers/ProcessedDocumentMapper.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/extract/mappers/ProcessedDocumentMapper.java
@@ -1,14 +1,14 @@
 package ca.bc.gov.open.jag.efilingreviewerapi.extract.mappers;
 
 
-import ca.bc.gov.open.jag.efilingreviewerapi.api.model.ProcessedDocument;
-import ca.bc.gov.open.jag.efilingreviewerapi.document.models.DocumentValidation;
-import ca.bc.gov.open.jag.efilingreviewerapi.document.models.DocumentValidationResult;
-import ca.bc.gov.open.jag.efilingreviewerapi.extract.models.ExtractResponse;
+import java.util.List;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-import java.util.List;
+import ca.bc.gov.open.jag.efilingreviewerapi.api.model.ProcessedDocument;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.models.DocumentValidationResult;
+import ca.bc.gov.open.jag.efilingreviewerapi.extract.models.ExtractResponse;
 
 @Mapper(componentModel = "spring")
 public interface ProcessedDocumentMapper {

--- a/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/restricteddocument/RestrictedDocumentApiDelegateImpl.java
+++ b/src/backend/efiling-reviewer-api/src/main/java/ca/bc/gov/open/jag/efilingreviewerapi/restricteddocument/RestrictedDocumentApiDelegateImpl.java
@@ -1,20 +1,20 @@
 package ca.bc.gov.open.jag.efilingreviewerapi.restricteddocument;
 
-import ca.bc.gov.open.jag.efilingreviewerapi.api.RestrictedDocumentTypesApiDelegate;
-import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentType;
-import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentTypeConfiguration;
-import ca.bc.gov.open.jag.efilingreviewerapi.api.model.RestrictedDocumentType;
-import ca.bc.gov.open.jag.efilingreviewerapi.document.store.RestrictedDocumentRepository;
-import ca.bc.gov.open.jag.efilingreviewerapi.restricteddocument.mappers.RestrictedDocumentTypeMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
+import ca.bc.gov.open.jag.efilingreviewerapi.api.RestrictedDocumentTypesApiDelegate;
+import ca.bc.gov.open.jag.efilingreviewerapi.api.model.DocumentType;
+import ca.bc.gov.open.jag.efilingreviewerapi.api.model.RestrictedDocumentType;
+import ca.bc.gov.open.jag.efilingreviewerapi.document.store.RestrictedDocumentRepository;
+import ca.bc.gov.open.jag.efilingreviewerapi.restricteddocument.mappers.RestrictedDocumentTypeMapper;
 
 @Service
 public class RestrictedDocumentApiDelegateImpl implements RestrictedDocumentTypesApiDelegate {

--- a/src/backend/libs/efiling-diligen-client/src/main/java/ca/bc/gov/open/efilingdiligenclient/diligen/mapper/DiligenDocumentDetailsMapper.java
+++ b/src/backend/libs/efiling-diligen-client/src/main/java/ca/bc/gov/open/efilingdiligenclient/diligen/mapper/DiligenDocumentDetailsMapper.java
@@ -1,13 +1,13 @@
 package ca.bc.gov.open.efilingdiligenclient.diligen.mapper;
 
-import ca.bc.gov.open.efilingdiligenclient.diligen.model.DiligenAnswerField;
+import java.util.List;
+
+import org.mapstruct.Mapper;
+
 import ca.bc.gov.open.efilingdiligenclient.diligen.model.DiligenDocumentDetails;
 import ca.bc.gov.open.jag.efilingdiligenclient.api.model.Field;
 import ca.bc.gov.open.jag.efilingdiligenclient.api.model.InlineResponse2003DataFileDetails;
 import ca.bc.gov.open.jag.efilingdiligenclient.api.model.ProjectFieldsResponse;
-import org.mapstruct.Mapper;
-
-import java.util.List;
 
 
 @Mapper

--- a/src/backend/libs/efiling-diligen-client/src/test/java/ca/bc/gov/open/efilingdiligenclient/diligen/diligenServiceImpl/DeleteDocumentTest.java
+++ b/src/backend/libs/efiling-diligen-client/src/test/java/ca/bc/gov/open/efilingdiligenclient/diligen/diligenServiceImpl/DeleteDocumentTest.java
@@ -1,5 +1,18 @@
 package ca.bc.gov.open.efilingdiligenclient.diligen.diligenServiceImpl;
 
+import static org.mockito.ArgumentMatchers.any;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
 import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenAuthService;
 import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenProperties;
 import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenServiceImpl;
@@ -8,15 +21,6 @@ import ca.bc.gov.open.efilingdiligenclient.exception.DiligenDocumentException;
 import ca.bc.gov.open.jag.efilingdiligenclient.api.DocumentsApi;
 import ca.bc.gov.open.jag.efilingdiligenclient.api.handler.ApiClient;
 import ca.bc.gov.open.jag.efilingdiligenclient.api.handler.ApiException;
-import org.junit.jupiter.api.*;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
-import java.math.BigDecimal;
-
-import static org.mockito.ArgumentMatchers.any;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("DiligenServiceImpl test suite")

--- a/src/backend/libs/efiling-diligen-client/src/test/java/ca/bc/gov/open/efilingdiligenclient/diligen/diligenServiceImpl/GetDocumentDetailsTest.java
+++ b/src/backend/libs/efiling-diligen-client/src/test/java/ca/bc/gov/open/efilingdiligenclient/diligen/diligenServiceImpl/GetDocumentDetailsTest.java
@@ -1,5 +1,23 @@
 package ca.bc.gov.open.efilingdiligenclient.diligen.diligenServiceImpl;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
 import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenAuthService;
 import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenProperties;
 import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenServiceImpl;
@@ -9,19 +27,13 @@ import ca.bc.gov.open.efilingdiligenclient.exception.DiligenDocumentException;
 import ca.bc.gov.open.jag.efilingdiligenclient.api.DocumentsApi;
 import ca.bc.gov.open.jag.efilingdiligenclient.api.handler.ApiClient;
 import ca.bc.gov.open.jag.efilingdiligenclient.api.handler.ApiException;
-import ca.bc.gov.open.jag.efilingdiligenclient.api.model.*;
-import org.junit.jupiter.api.*;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
+import ca.bc.gov.open.jag.efilingdiligenclient.api.model.Field;
+import ca.bc.gov.open.jag.efilingdiligenclient.api.model.FieldType;
+import ca.bc.gov.open.jag.efilingdiligenclient.api.model.InlineResponse2003;
+import ca.bc.gov.open.jag.efilingdiligenclient.api.model.InlineResponse2003Data;
+import ca.bc.gov.open.jag.efilingdiligenclient.api.model.InlineResponse2003DataFileDetails;
+import ca.bc.gov.open.jag.efilingdiligenclient.api.model.ProjectFieldsResponse;
+import ca.bc.gov.open.jag.efilingdiligenclient.api.model.ProjectFieldsResponseData;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("DiligenServiceImpl test suite")

--- a/src/backend/libs/efiling-diligen-client/src/test/java/ca/bc/gov/open/efilingdiligenclient/diligen/diligenServiceImpl/PostDocumentTest.java
+++ b/src/backend/libs/efiling-diligen-client/src/test/java/ca/bc/gov/open/efilingdiligenclient/diligen/diligenServiceImpl/PostDocumentTest.java
@@ -1,12 +1,16 @@
 package ca.bc.gov.open.efilingdiligenclient.diligen.diligenServiceImpl;
 
-import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenAuthService;
-import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenProperties;
-import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenServiceImpl;
-import ca.bc.gov.open.efilingdiligenclient.exception.DiligenDocumentException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -17,11 +21,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.math.BigDecimal;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
+import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenAuthService;
+import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenProperties;
+import ca.bc.gov.open.efilingdiligenclient.diligen.DiligenServiceImpl;
+import ca.bc.gov.open.efilingdiligenclient.exception.DiligenDocumentException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DisplayName("DiligenServiceImpl test suite")

--- a/src/backend/libs/efiling-mail-it/pom.xml
+++ b/src/backend/libs/efiling-mail-it/pom.xml
@@ -132,7 +132,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>4.3.1</version>
+				<version>5.1.1</version>
 				<executions>
 					<execution>
 						<id>spring-boot-api</id>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Bumped openapitools from 4.2.1 to 5.1.1
- Removed unused imports that was breaking the build.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [x] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

mvn verify -P all

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
