### PR TITLE
add dockerignore to backend build 

### DIFF
--- a/src/backend/.dockerignore
+++ b/src/backend/.dockerignore
@@ -1,0 +1,7 @@
+ai-reviewer-api/target
+ai-reviewer-cso-api/target
+ai-reviewer-mock-api/target
+libs/ai-bom/target
+libs/ai-diligen-client/target
+libs/ai-diligen-client-starter/target
+libs/ai-mail-it/target


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Added .dockerignore to backend.
docker-compose no longer tries to copy pre-compiled code into the docker container before the build process (which could cause issues when building openapitools in docker).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
