### PR TITLE
FLA-1163 - Add audit user to mongo table

### DIFF
--- a/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/Keys.java
+++ b/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/Keys.java
@@ -6,7 +6,8 @@ import java.util.List;
 public class Keys {
 
     private Keys() {}
-
+    
+    public static final String CLIENT_ID = "clientId";
     public static final String PROCESSED_STATUS = "PROCESSED";
     public static final String DOCUMENT_TYPE = "document-type";
     public static final List<String> ACCEPTED_STATUS = Arrays.asList("QUEUED_FOR_ML_ANALYSIS", "DONE_OCR_PROCESSING","QUEUED_FOR_OCR_PROCESSING", "QUEUED_FOR_TRANSLATE", "QUEUED_FOR_PROCESSING");

--- a/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/core/SecurityUtils.java
+++ b/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/core/SecurityUtils.java
@@ -1,0 +1,27 @@
+package ca.bc.gov.open.jag.aireviewerapi.core;
+
+import ca.bc.gov.open.jag.aireviewerapi.Keys;
+import org.keycloak.KeycloakPrincipal;
+import org.keycloak.KeycloakSecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+public class SecurityUtils {
+
+    private SecurityUtils() {
+    }
+
+    public static Optional<String> getClientId() {
+        return getOtherClaim(Keys.CLIENT_ID);
+    }
+
+    private static Optional<String> getOtherClaim(String claim) {
+        try {
+            return Optional.of(((KeycloakPrincipal<KeycloakSecurityContext>) SecurityContextHolder.getContext().getAuthentication().getPrincipal())
+                    .getKeycloakSecurityContext().getToken().getOtherClaims().get(claim).toString());
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/document/models/Auditable.java
+++ b/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/document/models/Auditable.java
@@ -2,15 +2,20 @@ package ca.bc.gov.open.jag.aireviewerapi.document.models;
 
 import java.util.Date;
 
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.annotation.Version;
+import org.springframework.data.annotation.*;
 
 /**
- * An abstract Auditable class that auto-populates <code>createdDate</code>, <code>modifiedDate</code>, and
- * <code>version</code> fields. Class need only to extend this class to add auditing fields to a model object.
+ * An abstract Auditable class that auto-populates <code>createdBy</code>, <code>lastModifiedBy</code>,
+ * <code>createdDate</code>, <code>modifiedDate</code>, and <code>version</code> fields. Class need only to
+ * extend this class to add auditing fields to a model object.
  */
 public abstract class Auditable {
+
+	@CreatedBy
+	protected String createdBy;
+
+	@LastModifiedBy
+	protected String lastModifiedBy;
 
 	@CreatedDate
 	protected Date createdDate;
@@ -20,6 +25,22 @@ public abstract class Auditable {
 
 	@Version
 	private Integer version;
+
+	public String getCreatedBy() {
+		return createdBy;
+	}
+
+	public void setCreatedBy(String createdBy) {
+		this.createdBy = createdBy;
+	}
+
+	public String getLastModifiedBy() {
+		return lastModifiedBy;
+	}
+
+	public void setLastModifiedBy(String lastModifiedBy) {
+		this.lastModifiedBy = lastModifiedBy;
+	}
 
 	public Date getCreatedDate() {
 		return createdDate == null ? new Date() : createdDate;

--- a/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/documentconfiguration/audit/AuditConfig.java
+++ b/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/documentconfiguration/audit/AuditConfig.java
@@ -1,6 +1,8 @@
 package ca.bc.gov.open.jag.aireviewerapi.documentconfiguration.audit;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 /**
@@ -12,4 +14,8 @@ import org.springframework.data.mongodb.config.EnableMongoAuditing;
 @EnableMongoAuditing
 public class AuditConfig {
 
+    @Bean
+    public AuditorAware<String> auditorAware() {
+        return new MongoAuditorAware();
+    }
 }

--- a/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/documentconfiguration/audit/MongoAuditorAware.java
+++ b/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/documentconfiguration/audit/MongoAuditorAware.java
@@ -1,0 +1,14 @@
+package ca.bc.gov.open.jag.aireviewerapi.documentconfiguration.audit;
+
+import ca.bc.gov.open.jag.aireviewerapi.core.SecurityUtils;
+import org.springframework.data.domain.AuditorAware;
+
+import java.util.Optional;
+
+public class MongoAuditorAware implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        return SecurityUtils.getClientId();
+    }
+}

--- a/src/backend/ai-reviewer-api/src/test/java/ca/bc/gov/open/jag/aireviewerapi/core/SecurityUtilsTest.java
+++ b/src/backend/ai-reviewer-api/src/test/java/ca/bc/gov/open/jag/aireviewerapi/core/SecurityUtilsTest.java
@@ -1,0 +1,69 @@
+package ca.bc.gov.open.jag.aireviewerapi.core;
+
+import ca.bc.gov.open.jag.aireviewerapi.Keys;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.keycloak.KeycloakPrincipal;
+import org.keycloak.KeycloakSecurityContext;
+import org.keycloak.representations.AccessToken;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Security Utils Test Suite")
+@ExtendWith(MockitoExtension.class)
+public class SecurityUtilsTest {
+
+    @Mock
+    private SecurityContext securityContextMock;
+
+    @Mock
+    private Authentication authenticationMock;
+
+    @Mock
+    private KeycloakPrincipal<KeycloakSecurityContext> keycloakPrincipalMock;
+
+    @Mock
+    private KeycloakSecurityContext keycloakSecurityContextMock;
+
+    @Mock
+    private AccessToken tokenMock;
+
+    @BeforeEach
+    public void setup() {
+
+        Mockito.when(securityContextMock.getAuthentication()).thenReturn(authenticationMock);
+        Mockito.when(authenticationMock.getPrincipal()).thenReturn(keycloakPrincipalMock);
+        Mockito.when(keycloakPrincipalMock.getKeycloakSecurityContext()).thenReturn(keycloakSecurityContextMock);
+        Mockito.when(keycloakSecurityContextMock.getToken()).thenReturn(tokenMock);
+        SecurityContextHolder.setContext(securityContextMock);
+    }
+
+    @Test
+    @DisplayName("Assert client id returned")
+    public void shouldConvertToUUID() {
+
+        String expectedUUID = UUID.randomUUID().toString();
+
+        // arrange
+        Map<String, Object> otherClaims = new HashMap<>();
+        otherClaims.put(Keys.CLIENT_ID, expectedUUID);
+        Mockito.when(tokenMock.getOtherClaims()).thenReturn(otherClaims);
+
+        // act
+        Optional<String> actual = SecurityUtils.getClientId();
+
+        // assert
+        Assertions.assertTrue(actual.isPresent());
+        Assertions.assertEquals(expectedUUID, actual.get());
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FLA-1163
- Add createdBy and lastModifiedBy fields to Auditable
- Populated createdBy and lastModifiedBy from security token via SecurityUtils => MongoAuditorAware => AuditConfig

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Existing unit test via DocumentConfigurationsEventListenerTest and Postman for Create Document Type Configuration, Update Document Type Configuration and Delete Document Type Configuration.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
