### PR TITLE
FLA-1163 - Renamed MongoAuditorAware to AuditorAwareImpl

### DIFF
--- a/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/documentconfiguration/audit/AuditConfig.java
+++ b/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/documentconfiguration/audit/AuditConfig.java
@@ -16,6 +16,6 @@ public class AuditConfig {
 
     @Bean
     public AuditorAware<String> auditorAware() {
-        return new MongoAuditorAware();
+        return new AuditorAwareImpl();
     }
 }

--- a/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/documentconfiguration/audit/AuditorAwareImpl.java
+++ b/src/backend/ai-reviewer-api/src/main/java/ca/bc/gov/open/jag/aireviewerapi/documentconfiguration/audit/AuditorAwareImpl.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.AuditorAware;
 
 import java.util.Optional;
 
-public class MongoAuditorAware implements AuditorAware<String> {
+public class AuditorAwareImpl implements AuditorAware<String> {
 
     @Override
     public Optional<String> getCurrentAuditor() {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FLA-1163
- Renamed MongAuditorAware to AuditorAwareImpl

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Local unit tests passed and functionality was confirmed in Postman and Mongo DB.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
